### PR TITLE
automake: Remove duplicate words in aclocal.in

### DIFF
--- a/bin/aclocal.in
+++ b/bin/aclocal.in
@@ -284,7 +284,7 @@ sub install_file ($$)
 	    {
 	      # $dest does not exist.  We create an empty one just to
 	      # run diff, and we erase it afterward.  Using the real
-	      # the destination file (rather than a temporary file) is
+	      # destination file (rather than a temporary file) is
 	      # good when diff is run with options that display the
 	      # file name.
 	      #


### PR DESCRIPTION
"Using the real the destination file (rather than a temporary file)" should be written "Using the real destination file (rather than a temporary file)".

* bin/aclocal.in: Remove duplicate words.