### PR TITLE
Adding the "bootstrap" instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -50,7 +50,8 @@ you want to change it or regenerate 'configure' using a newer version of
    The simplest way to compile this package is:
 
   1. 'cd' to the directory containing the package's source code and type
-     './configure' to configure the package for your system.
+     './configure' to configure the package for your system. You may need
+     to run './bootstrap' if you are install automake for the first time.
 
      Running 'configure' might take a while.  While running, it prints
      some messages telling which features it is checking for.


### PR DESCRIPTION
It may be obvious, but I didn't understand how to create the config file from the configure.ac. I didn't see the command to run "./bootstrap," but it ended up working for me.  We don't have to add the instructions here, but maybe this should be mentioned in the INSTALL directions?